### PR TITLE
fix: pre-load SSL certs in background thread to avoid blocking event loop

### DIFF
--- a/custom_components/datadog_agentless/__init__.py
+++ b/custom_components/datadog_agentless/__init__.py
@@ -7,6 +7,8 @@ import dateutil.parser
 import json
 import orjson
 import asyncio
+import ssl
+import threading
 from collections.abc import Callable
 
 
@@ -65,6 +67,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     api_client = AsyncApiClient(configuration)
     metrics_api = MetricsApi(api_client)
+
+    # Pre-load SSL default certificates in a background thread to avoid
+    # blocking the event loop on the first API call (Python 3.14+).
+    # See https://github.com/kamaradclimber/datadog-integration-ha/issues/46
+    def _warm_ssl_context():
+        ssl.create_default_context()
+    threading.Thread(target=_warm_ssl_context, daemon=True).start()
 
     # Store api_client for cleanup
     hass.data[DOMAIN][entry.entry_id]["api_client"] = api_client


### PR DESCRIPTION
## Problem

On Python 3.14+, `ssl.SSLContext.load_default_certs()` blocks the event loop on the first API call. This freezes the HA HTTP server, causing Kubernetes liveness probe failures (exit code 137).

Fixes #46

## Solution

Warm up the SSL context in a daemon thread at integration setup time, before any API calls are made. By the time `submit_metrics` or `create_event` is called (10+ seconds later), the SSL module cache is already warm and no blocking occurs.

## Changes

- Added `import ssl` and `import threading`
- Spawn a daemon thread calling `ssl.create_default_context()` after `AsyncApiClient` creation

## Why this approach

Wrapping every API call with `asyncio.to_thread()` would move the entire HTTP request off the event loop, losing the benefits of async I/O. The SSL setup is the only blocking part — the warmup targets exactly that.

## Testing

- Existing unit tests pass
- No behavioral change to API calls themselves